### PR TITLE
Add zizmor and harden GitHub Actions workflows

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -39,16 +39,19 @@ runs:
     - name: Install additional APT packages
       if: inputs.additional-apt-packages != ''
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y ${{ inputs.additional-apt-packages }}
+      env:
+        ADDITIONAL_APT_PACKAGES: ${{ inputs.additional-apt-packages }}
+      run: sudo apt-get update && sudo apt-get install -y ${ADDITIONAL_APT_PACKAGES}
 
     - name: Set up micromamba
       if: ${{ inputs.install-slim == 'true' }}
-      uses: mamba-org/setup-micromamba@v2.0.4
+      uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476  # v3.0.0
 
     - name: Install SLiM
       if: ${{ inputs.install-slim == 'true' }}
       shell: bash
-      run: |
+      # MAMBA_ROOT_PREFIX is a fixed, controlled path set by setup-micromamba, not attacker-controlled.
+      run: | # zizmor: ignore[github-env]
         micromamba install -n base -y slim
         echo "$MAMBA_ROOT_PREFIX/bin" >> $GITHUB_PATH
 
@@ -58,19 +61,23 @@ runs:
       run: slim -v
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       with:
         version: "0.10.0"
 
     - name: Install doc deps
       shell: bash
-      run: uv sync --no-default-groups --project=${{ inputs.pyproject-directory }} --locked --group docs
+      env:
+        PYPROJECT_DIRECTORY: ${{ inputs.pyproject-directory }}
+      run: uv sync --no-default-groups --project=${PYPROJECT_DIRECTORY} --locked --group docs
 
     - name: Set build version
       shell: bash
+      env:
+        PYPROJECT_DIRECTORY: ${{ inputs.pyproject-directory }}
       run: |
         set -euo pipefail
-        export PROJECT_DIR="${{ inputs.pyproject-directory }}"
+        export PROJECT_DIR="${PYPROJECT_DIRECTORY}"
         PKG_VERSION="$(
         uv run --no-default-groups --project "$PROJECT_DIR" python - <<PY
         import os, tomllib, pathlib, importlib.metadata as m
@@ -86,7 +93,9 @@ runs:
     - name: Pre-build
       if: inputs.pre-build-command != ''
       shell: bash
-      run: ${{ inputs.pre-build-command }}
+      env:
+        PRE_BUILD_COMMAND: ${{ inputs.pre-build-command }}
+      run: ${PRE_BUILD_COMMAND}
 
     - name: Build documentation
       shell: bash

--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -77,11 +77,10 @@ runs:
         PYPROJECT_DIRECTORY: ${{ inputs.pyproject-directory }}
       run: |
         set -euo pipefail
-        export PROJECT_DIR="${PYPROJECT_DIRECTORY}"
         PKG_VERSION="$(
-        uv run --no-default-groups --project "$PROJECT_DIR" python - <<PY
+        uv run --no-default-groups --project "$PYPROJECT_DIRECTORY" python - <<PY
         import os, tomllib, pathlib, importlib.metadata as m
-        project_dir = pathlib.Path(os.environ['PROJECT_DIR'])
+        project_dir = pathlib.Path(os.environ['PYPROJECT_DIRECTORY'])
         data = tomllib.loads((project_dir / 'pyproject.toml').read_text())
         name = data['project']['name']
         print(m.version(name))

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -14,25 +14,31 @@ on:
         type: string
         default: '["ubuntu-24.04", "windows-2025", "macos-15-intel", "macos-14"]'
 
+permissions:
+  contents: read
+
 jobs:
   build-sdist:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
           submodules: true
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           version: "0.10.0"
 
       - name: Build sdist
-        run: uv build --project=${{ inputs.pyproject-directory }} --sdist -o dist
+        env:
+          PYPROJECT_DIRECTORY: ${{ inputs.pyproject-directory }}
+        run: uv build --project=${PYPROJECT_DIRECTORY} --sdist -o dist
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: build-sdist
           path: dist/*.tar.gz
@@ -47,14 +53,16 @@ jobs:
         os: ${{ fromJSON(inputs.os-list) }}
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66  # 0.13.1
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Download artifacts
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: build-sdist
 
@@ -69,13 +77,15 @@ jobs:
         run: cp *.tar.gz sdist.tar.gz
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           version: "0.10.0"
 
       - name: Install cibuildwheel
-        run: uv sync --project=${{ inputs.pyproject-directory }} --locked --only-group wheels
-    
+        env:
+          PYPROJECT_DIRECTORY: ${{ inputs.pyproject-directory }}
+        run: uv sync --project=${PYPROJECT_DIRECTORY} --locked --only-group wheels
+
       - name: Set CIBW_ARCHS_MACOS based on native arch
         if: runner.os == 'macOS'
         shell: bash
@@ -88,12 +98,14 @@ jobs:
           else
             echo "Unknown macOS architecture: $ARCH"
             exit 1
-          fi 
-          
-      - name: Build wheels
-        run: uv run --only-group wheels --project=${{ inputs.pyproject-directory }} cibuildwheel sdist.tar.gz
+          fi
 
-      - uses: actions/upload-artifact@v4
+      - name: Build wheels
+        env:
+          PYPROJECT_DIRECTORY: ${{ inputs.pyproject-directory }}
+        run: uv run --only-group wheels --project=${PYPROJECT_DIRECTORY} cibuildwheel sdist.tar.gz
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: build-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/c-tests.yml
+++ b/.github/workflows/c-tests.yml
@@ -13,6 +13,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   c-tests:
     name: C unit tests
@@ -20,23 +23,26 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.13.0
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66  # 0.13.1
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
+          persist-credentials: false
 
-      - name: Install system deps 
+      - name: Install system deps
+        env:
+          ADDITIONAL_APT_PACKAGES: ${{ inputs.additional-apt-packages }}
         run: |
           sudo apt-get update
           sudo apt-get install -y libcunit1-dev libconfig-dev \
-            ninja-build valgrind clang  ${{ inputs.additional-apt-packages }}
-      
+            ninja-build valgrind clang  ${ADDITIONAL_APT_PACKAGES}
+
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           version: "0.10.0"
 
@@ -46,11 +52,13 @@ jobs:
           uv tool install gcovr==8.6
 
       - name: Configure code
-        run: CC=gcc meson setup -Db_coverage=true build-cov ${{ inputs.library-directory }}
+        env:
+          LIBRARY_DIRECTORY: ${{ inputs.library-directory }}
+        run: CC=gcc meson setup -Db_coverage=true build-cov ${LIBRARY_DIRECTORY}
 
       - name: Compile
         run: ninja -C build-cov
-      
+
       - name: Run tests
         run: ninja -C build-cov test
 
@@ -58,20 +66,24 @@ jobs:
         run: ninja -C build-cov coverage-xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: C
           gcov_args: --preserve-paths
           fail_ci_if_error: true
-         
+
       - name: Compile and test with clang
+        env:
+          LIBRARY_DIRECTORY: ${{ inputs.library-directory }}
         run: |
-          CC=clang meson setup build-clang ${{ inputs.library-directory }}
-          ninja -C build-clang test 
+          CC=clang meson setup build-clang ${LIBRARY_DIRECTORY}
+          ninja -C build-clang test
 
       - name: Run tests with valgrind
+        env:
+          LIBRARY_DIRECTORY: ${{ inputs.library-directory }}
         run: |
-          meson setup build-valgrind ${{ inputs.library-directory }}          
+          meson setup build-valgrind ${LIBRARY_DIRECTORY}
           meson test -C build-valgrind -t-1 \
             --wrapper='valgrind --leak-check=full --error-exitcode=1'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,19 +35,23 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   Docs:
     name: Build docs
     runs-on: ubuntu-24.04
     steps:
-      - uses: styfle/cancel-workflow-action@0.12.1
+      - uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66  # 0.13.1
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: tskit-dev/.github/.github/actions/build-docs@main
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,22 +12,26 @@ on:
         type: string
         default: '.'
 
+permissions:
+  contents: read
+
 jobs:
   prek:
     name: Lint
     runs-on: ubuntu-24.04
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66  # 0.13.1
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           version: "0.10.0"
 
@@ -35,9 +39,13 @@ jobs:
         # Note there is some subtlety here in using the --only-group approach.
         # We **do not** install the local package, which means we don't need
         # any system dependencies, but it can lead to oddities.
-        run: uv sync --locked --project=${{ inputs.pyproject-directory }} --only-group lint
+        env:
+          PYPROJECT_DIRECTORY: ${{ inputs.pyproject-directory }}
+        run: uv sync --locked --project=${PYPROJECT_DIRECTORY} --only-group lint
 
       - name: Run prek
+        env:
+          PYPROJECT_DIRECTORY: ${{ inputs.pyproject-directory }}
         run: |
-          uv run --locked --project=${{ inputs.pyproject-directory }} --only-group lint \
+          uv run --locked --project=${PYPROJECT_DIRECTORY} --only-group lint \
           prek -c prek.toml run --all-files --show-diff-on-failure

--- a/.github/workflows/python-c-tests.yml
+++ b/.github/workflows/python-c-tests.yml
@@ -19,6 +19,9 @@ on:
         type: string
         default: 'tests/test_python_c.py'
 
+permissions:
+  contents: read
+
 jobs:
   python-c-tests:
     name: Python-C unit tests
@@ -26,27 +29,32 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.13.0
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66  # 0.13.1
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Install dev tools
         if: ${{ inputs.additional-apt-packages != '' }}
+        env:
+          ADDITIONAL_APT_PACKAGES: ${{ inputs.additional-apt-packages }}
         run: |
-          sudo apt-get update && sudo apt-get install -y ${{ inputs.additional-apt-packages }}
+          sudo apt-get update && sudo apt-get install -y ${ADDITIONAL_APT_PACKAGES}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           version: "0.10.0"
 
       - name: Install Python dependencies
-        run: uv sync  --project=${{ inputs.pyproject-directory }} --locked --group test --no-default-groups
+        env:
+          PYPROJECT_DIRECTORY: ${{ inputs.pyproject-directory }}
+        run: uv sync  --project=${PYPROJECT_DIRECTORY} --locked --group test --no-default-groups
 
       - name: Install gcovr
         run: uv tool install gcovr==8.6
@@ -56,15 +64,18 @@ jobs:
         run: CFLAGS=--coverage uv run --no-default-groups python setup.py build_ext --inplace
 
       - name: Run low-level tests
+        env:
+          PYPROJECT_DIRECTORY: ${{ inputs.pyproject-directory }}
+          TESTS: ${{ inputs.tests }}
         run: |
-          uv run --project=${{ inputs.pyproject-directory }} --locked --group test --no-default-groups \
-            pytest ${{ inputs.tests }}
+          uv run --project=${PYPROJECT_DIRECTORY} --locked --group test --no-default-groups \
+            pytest ${TESTS}
 
       - name: Run gcovr
         run: uv tool run gcovr --clover coverage.xml --txt
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -18,27 +18,33 @@ on:
         default: ''
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   python-packaging:
     name: Python packaging tests
     runs-on: ubuntu-24.04
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66  # 0.13.1
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
           fetch-depth: 0
-          
+          persist-credentials: false
+
       - name: Install additional APT packages
         if: ${{ inputs.additional-apt-packages != '' }}
-        run: sudo apt-get update && sudo apt-get install -y ${{ inputs.additional-apt-packages }}
+        env:
+          ADDITIONAL_APT_PACKAGES: ${{ inputs.additional-apt-packages }}
+        run: sudo apt-get update && sudo apt-get install -y ${ADDITIONAL_APT_PACKAGES}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           version: "0.10.0"
 
@@ -67,6 +73,8 @@ jobs:
       - name: Run CLI (if present)
         if: ${{ inputs.cli-test-cmd != '' }}
         working-directory: ${{ inputs.pyproject-directory }}
+        env:
+          CLI_TEST_CMD: ${{ inputs.cli-test-cmd }}
         run: |
           source cli-test/bin/activate
-          ./cli-test/bin/${{ inputs.cli-test-cmd }}
+          ./cli-test/bin/${CLI_TEST_CMD}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,6 +26,9 @@ on:
         type: string
         default: "false"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Unit tests
@@ -35,14 +38,15 @@ jobs:
         shell: bash
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66  # 0.13.1
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Fix windows symlinks
         if: ${{ inputs.fix-lwt-symlink == 'true' && runner.os == 'Windows' }}
@@ -52,25 +56,32 @@ jobs:
 
       - name: Install additional APT packages
         if: ${{ inputs.additional-apt-packages != '' }}
-        run: sudo apt-get update && sudo apt-get install -y ${{ inputs.additional-apt-packages }}
+        env:
+          ADDITIONAL_APT_PACKAGES: ${{ inputs.additional-apt-packages }}
+        run: sudo apt-get update && sudo apt-get install -y ${ADDITIONAL_APT_PACKAGES}
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           python-version: ${{ inputs.python-version }}
           version: "0.10.0"
 
       - name: Install test deps
-        run: uv sync --project=${{ inputs.pyproject-directory }} --locked --group test --no-default-groups
+        env:
+          PYPROJECT_DIRECTORY: ${{ inputs.pyproject-directory }}
+        run: uv sync --project=${PYPROJECT_DIRECTORY} --locked --group test --no-default-groups
 
       - name: Run tests
+        env:
+          PYPROJECT_DIRECTORY: ${{ inputs.pyproject-directory }}
+          COVERAGE_DIRECTORY: ${{ inputs.coverage-directory }}
         run: |
-          uv run  --project=${{ inputs.pyproject-directory }} --locked --group test --no-default-groups \
-            pytest --cov-report=xml --cov-branch -n2 --cov=${{ inputs.coverage-directory }} \
-            ${{ inputs.pyproject-directory }}/tests
+          uv run  --project=${PYPROJECT_DIRECTORY} --locked --group test --no-default-groups \
+            pytest --cov-report=xml --cov-branch -n2 --cov=${COVERAGE_DIRECTORY} \
+            ${PYPROJECT_DIRECTORY}/tests
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: zizmor
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          enable-cache: false
+
+      - name: Run zizmor
+        run: uvx zizmor@1.26.1 .github/
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+# zizmor configuration for tskit-dev repos.
+# Third-party actions must be hash-pinned; first-party tskit-dev reusable
+# workflows/actions are trusted and may stay pinned to a version tag or branch.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        tskit-dev/*: ref-pin
+        "*": hash-pin


### PR DESCRIPTION
[Zizmor](https://github.com/tskit-dev/sc2ts/pull/614) is a static analysis method for GitHub actions which mitigates against supply chain attacks (which are a real and scary thing). I think it would be good to apply this across the tskit-dev ecosystem so that we don't get packages hijacked (however unlikely that is).

