### PR TITLE
allow slim to be built from source

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -28,6 +28,11 @@ inputs:
     required: false
     default: 'false'
 
+  install-slim-branch:
+    description: 'Name of github branch to install SLiM from (if not specified, use conda)'
+    required: false
+    default: ''
+
   install-playwright:
     description: 'Install Playwright (chromium) for docs that render browser screenshots'
     required: false
@@ -44,21 +49,36 @@ runs:
       run: sudo apt-get update && sudo apt-get install -y ${ADDITIONAL_APT_PACKAGES}
 
     - name: Set up micromamba
-      if: ${{ inputs.install-slim == 'true' }}
+      if: ${{ inputs.install-slim == 'true' && inputs.install-slim-branch == '' }}
       uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476  # v3.0.0
 
     - name: Install SLiM
-      if: ${{ inputs.install-slim == 'true' }}
+      if: ${{ inputs.install-slim == 'true' && inputs.install-slim-branch == '' }}
       shell: bash
       # MAMBA_ROOT_PREFIX is a fixed, controlled path set by setup-micromamba, not attacker-controlled.
       run: | # zizmor: ignore[github-env]
         micromamba install -n base -y slim
         echo "$MAMBA_ROOT_PREFIX/bin" >> $GITHUB_PATH
 
+    - name: Install development SLiM
+      if: ${{ inputs.install-slim == 'true' && inputs.install-slim-branch != '' }}
+      shell: bash
+      env:
+        SLIM_BRANCH: ${{ inputs.install-slim-branch }}
+      run: |
+        git clone https://github.com/messerlab/SLiM.git
+        mkdir -p SLiM/Release
+        cd SLiM/Release
+        git checkout ${SLIM_BRANCH}
+        cmake -DCMAKE_BUILD_TYPE=Release ..
+        make -j 2
+
     - name: Verify SLiM
       if: ${{ inputs.install-slim == 'true' }}
       shell: bash
-      run: slim -v
+      run: |
+        export PATH=$PWD/SLiM/Release:$PATH
+        slim -v
 
     - name: Install uv
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -99,4 +119,6 @@ runs:
     - name: Build documentation
       shell: bash
       working-directory: docs
-      run: make
+      run: |
+        export PATH=$PWD/../SLiM/Release:$PATH
+        make

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: tskit-dev/.github/.github/actions/build-docs@main
+      - uses: $/.github/actions/build-docs
         with:
           pyproject-directory: ${{ inputs.pyproject-directory }}
           additional-apt-packages: ${{ inputs.additional-apt-packages }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,12 @@ on:
         type: boolean
         default: false
 
+      install-slim-branch:
+        description: 'Name of github branch to install SLiM from (if not specified, use conda)'
+        required: false
+        type: string
+        default: ''
+
       install-playwright:
         description: 'Install Playwright (chromium) for docs that render browser screenshots'
         required: false
@@ -58,6 +64,7 @@ jobs:
           pyproject-directory: ${{ inputs.pyproject-directory }}
           additional-apt-packages: ${{ inputs.additional-apt-packages }}
           install-slim: ${{ inputs.install-slim }}
+          install-slim-branch: ${{ inputs.install-slim-branch }}
           install-playwright: ${{ inputs.install-playwright }}
 
       - name: Trigger tskit-site rebuild

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -24,6 +24,6 @@ jobs:
           enable-cache: false
 
       - name: Run zizmor
-        run: uvx zizmor@1.26.1 .github/
+        run: uvx zizmor@1.29.0 .github/
         env:
           GH_TOKEN: ${{ github.token }}

--- a/repo_administration.md
+++ b/repo_administration.md
@@ -314,6 +314,12 @@ old minimum Python version and update them to the new minimum. In particular:
 
 - Any bespoke workflow steps that install or invoke a specific Python version directly.
 
+### Debugging workflows
+
+If there's a problem with a workflow or action file, the CI action will fail to run,
+and the status in a PR will show as "waiting for status". To see what's gone wrong,
+go to the Actions tab in github and find the workflow.
+
 ## Releases
 
 Python releases use the `wheels.yml` workflow via the Trusted Publisher PyPI mechanism.


### PR DESCRIPTION
For instance, I'm currently working on pyslim, which needs to use the current in-development `multitrait` branch of SLiM.